### PR TITLE
Feature/input weather without reference et

### DIFF
--- a/aquacrop/utils/__init__.py
+++ b/aquacrop/utils/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
 if not "-m" in sys.argv:
-    from .prepare_weather import prepare_weather
+    from .prepare_weather import prepare_weather, prepare_weather_from_daymet
     from .data import get_filepath
     from .lars import prepare_lars_weather, select_lars_wdf

--- a/aquacrop/utils/__init__.py
+++ b/aquacrop/utils/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
 if not "-m" in sys.argv:
-    from .prepare_weather import prepare_weather, prepare_weather_from_daymet
+    from .prepare_weather import prepare_weather, prepare_weather_minimum_data
     from .data import get_filepath
     from .lars import prepare_lars_weather, select_lars_wdf

--- a/aquacrop/utils/prepare_weather.py
+++ b/aquacrop/utils/prepare_weather.py
@@ -1,4 +1,19 @@
+#-----------------------------------------------------------------------------------------
+# CHANGES IMPLEMENTED BY KADE FLYNN AUGUST 2025
+#-----------------------------------------------------------------------------------------
+#- Add function prepare_weather_from_daymet() to format weather data downloaded from Daymet (https://daymet.ornl.gov/) for use in Aquacrop. As part of this function, reference ET is calculated...
+#- Add function to calculate Reference ET according to Allen (1998). Wind speed data is   assumed to be equal to 2 m/s.
+#- Add functions to calculate net radiaition from input weather data. Net radiation calculation is based on equations in An Introduction to Environmental Biophysics (Campbell and Norman, 1998). Equations include:
+#   - calculate_net_radiation()
+#   - _calculate_saturated_vapor_pressure()
+#   - _calculate_clear_sky_emissivity()
+#   - _calculate_total_radiant_energy_emmitted()
+#   - _calculate_max_radiation
+#   - _calculate_cloud_correction()
+#-----------------------------------------------------------------------------------------
+
 import pandas as pd
+import numpy as np  # required for changes implemented by kade flynn AUgust 2025
 
 
 def prepare_weather(weather_file_path):
@@ -39,3 +54,223 @@ weather_df (pandas.DataFrame):  weather data for simulation period
 
     return weather_df
 
+def prepare_weather_from_daymet(weather_file_path: str, latitude: float, longitude: float, elevation: float):
+    """
+    function to read in weather data from DAYMET and return a dataframe containing the weather data.
+
+    Arguments:
+    - file path to daymmet download. File structure:
+        - Column names begin on row 7
+        - Columns are:
+            - year, yday, dayl (s), srad (W/m^2), swe (kg/m^2), tmax (deg c) tmin (deg c), vp(Pa)
+    - latitude
+    -longitude
+    -elevation
+
+    Returns:
+    - weather_df (pandas.DataFrame):  weather data for simulation period
+
+    """
+
+    weather_df = pd.read_csv(weather_file_path, skiprows=6, header=0)
+
+    assert len(weather_df.columns) == 9
+
+    # rename the columns
+    weather_df.columns = str(
+        "Year Yday Dayl_s Precip_mm Srad_wm2 Swe_kgm2 Tmax_c Tmin_c Vp_pa").split()
+
+    # put the weather dates into datetime format
+    weather_df['Date_Yj'] = pd.to_datetime(weather_df['Year'].astype(str) + '-' + weather_df['Yday'].astype(str), format='%Y-%j')
+    weather_df['Date'] = weather_df['Date_Yj'].dt.strftime('%Y-%m-%d')
+
+    # drop the  date in year-yday format columns
+    weather_df = weather_df.drop(["Date_Yj"], axis=1)
+
+    # calculate incoming shortwave (solar) radiation
+    weather_df['Solar_mjm2'] = weather_df['Srad_wm2'] * weather_df['Dayl_s'] / 1_000_000
+
+    # drop shortwave radiation flux density, day length, snow water equivalent
+    weather_df = weather_df.drop(['Srad_wm2', 'Dayl_s', 'Swe_kgm2'], axis=1)
+
+    # Calculate Net Radiation
+    weather_df['Rn'] = calculate_net_radiation(Tmin = weather_df['Tmin_c'],
+                                               Tmax = weather_df['Tmax_c'],
+                                               Solar = weather_df['Solar_mjm2'],
+                                               Vp = weather_df['Vp_pa'],
+                                               Yday = weather_df['Yday'],
+                                               Latitude = latitude,
+                                               Longitude = longitude,
+                                               Elevation = elevation)
+    # Calculate Reference ET
+    weather_df['ReferenceET'] = calculate_reference_et()
+
+    # set limit on ET0 to avoid divide by zero errors
+    #weather_df['ReferenceET'] = weather_df['ReferenceET'].clip(lower=0.1)
+
+    return weather_df
+
+
+def calculate_reference_et(Rn, Vp):
+    '''Calculate Reference ET with the FAO Penman-Monteith equation (Equation 3, Allen et al. 1998).
+    
+    Arguments:
+    -net radiation
+    -soil heat flux
+    -vapor pressure
+    -saturated vapor pressure
+    -minimum daily temperatuer
+    -maximum daily temperature
+    -psychrometric constant 
+    '''
+    numerator
+
+def calculate_net_radiation(Tmin, Tmax, Solar, Vp, Yday, Latitude, Longitude, Elevation):
+    '''
+    Function to calculate the net radiation. General reference is An Introduction to Environmental Biophysics (Campbell and Norman, 1998).
+
+    Parameters:
+    -----------
+    Tmin : float
+        Minimum daily temperature in degrees celcius
+    Tmax : float
+        Maximum daily temperature in degrees celsius
+    Solar: float
+        Incoming shortwave (solar) radiation in Mj/m^2
+    Vp : float
+        Vapor pressure in Pascales 
+    Latitude: float
+        latitude in degrees
+    Longitude: float
+        longitude in degrees
+    
+    Result:
+    -------
+    NetRadiation
+        Object containing the net radiation and related variables
+    '''
+    Temperature = (Tmin + Tmax) / 2
+
+    saturated_vapor_pressure, slope_saturated_vapor_pressure_curve = _calculate_saturated_vapor_pressure(temperature = Temperature)
+
+    clear_sky_emissivity = _calculate_clear_sky_emissivity(temperature = Temperature, vapor_pressure = Vp)
+
+    total_radiant_energy_emitted = _calculate_total_radiant_energy_emitted(temperature = Temperature, clear_sky_emissivity = clear_sky_emissivity)
+    
+    max_radiation, day_length = _calculate_max_radiation(latitude = Latitude, longitude = Longitude, standard_meridian = Longitude, elevation = Elevation, day_of_year = Yday, solar_radiation = Solar)
+    
+    cloud_correction = _calculate_cloud_correction(solar_radiation = Solar, max_radiation = max_radiation)
+
+    albedo = 0.23
+    net_radiation = Solar * (1-albedo) + total_radiant_energy_emitted * cloud_correction
+
+    return net_radiation
+
+def _calculate_saturated_vapor_pressure(temperature):
+    '''
+    Function to calculate the saturated vapor pressure and the slope of the saturated vapor pressure curve
+    using Tetens formula. Equation 3.8 from An Introduction to Environmental Biophysics (Campbell and Norman, 1998).
+    '''
+    a = 0.611
+    b = 17.502
+    c = 240.970
+    saturated_vapor_pressure = a * (np.exp(b*temperature/(temperature+c)))
+
+    slope_saturated_vapor_pressure_curve = b*c*saturated_vapor_pressure/\
+        ((temperature+c)**2) / 101.3
+
+    return saturated_vapor_pressure, slope_saturated_vapor_pressure_curve
+
+def _calculate_clear_sky_emissivity(temperature: int, vapor_pressure: int):
+    '''
+    Function to calculate the clear sky emissivity. Equation 10.10 from An Introduction to
+    Environmental Biophysics (Campbell and Norman, 1998).
+    '''
+
+    clear_sky_emissivity = 1.72 * ((vapor_pressure/1000)/(temperature+273))**(1/7)
+
+    return clear_sky_emissivity
+
+def _calculate_total_radiant_energy_emitted(temperature: int, clear_sky_emissivity: int):
+    '''
+    Function to calculate the total radiant energy emitted by a blackbody. Equation 10.9 from An Introduction to
+    Environmental Biophysics (Campbell and Norman, 1998).
+    '''
+
+    total_radiant_energy_emitted = 0.98 * (clear_sky_emissivity-1) * 5.67e-8 * (temperature+273)**4
+    # convert to Mj/m2. Output of Stefan-Boltzmann law is W/m2
+    total_radiant_energy_emitted = total_radiant_energy_emitted * 14 * 3600 * 1e-6
+
+    return total_radiant_energy_emitted
+
+
+def _calculate_max_radiation(latitude: int, longitude: int, standard_meridian: int,
+                              elevation: int, day_of_year: int, solar_radiation: int):
+    '''
+    Function to calculate the maximum radiation for a given location. General reference
+    is An Introduction to Environmental Biophysics (Campbell and Norman, 1998). pages 168 to 173.
+    '''
+    # extraterrestrial flux density normal to the solar beam [W/m^2]
+    spo = 1360
+    # atmoshperic transmittance
+    tao = 0.75
+    # calculate atmospheric pressure
+    pa = 101.3 * np.exp(-elevation/8200)
+    # Equation of time (Eq. 11.4)
+    f = 279.575 + 0.9856 * day_of_year
+    # convert f from radians to degrees
+    f = f * (np.pi / 180)
+
+    et = (-104.7 * np.sin((f)) + 596.2 * np.sin((2*f)) + 4.3*np.sin((3*f)) -\
+          12.7*np.sin((4*f)) - 429.3*np.cos((f)) - 2*np.cos((2*f)) +\
+            19.3*np.cos((3*f))) / 3600
+    # solar declination angle in degrees (Eq. 11.5)
+    sigma = (180/np.pi) * (np.asin(0.39785*np.sin((np.pi/180)*(278.97 + 0.9856*day_of_year + 1.9165*\
+                                                                   np.sin((np.pi/180)*(356.6+0.9856*day_of_year))))))
+    # longitude correction
+    lc = (standard_meridian-longitude) / 15
+    # solar noon (Eq 11.3)
+    to = 12 - lc - et
+    # Calculate half day length in degrees (Eq 11.6)
+    hs = (180 / np.pi) * np.acos(-np.sin((np.pi/180)*(latitude)) * np.sin((np.pi/180)*(sigma)) /\
+                                     (np.cos((np.pi/180)*(latitude))*np.cos((np.pi/180)*(sigma))))
+    # time of sunrise (Eq 11.7)
+    tr = np.round(0.5 + (to - hs/15))
+    # time of sunset
+    ts = np.round((to + hs/15) - 0.5)
+    # hours in day from sunrise to sunset 
+    #t = [x for x in range(tr, ts, 1)]
+    # get daylength
+    #day_length = len(t)
+    day_length = ts - tr
+    # # hourly zenith angle  (Eq. 11.1)
+    # psi = 180/math.pi * math.acos(math.sin((math.pi/180)*(latitude))*math.sin((math.pi/180)*(sigma)) + math.cos((math.pi/180)*(latitude))*\
+    #                             math.cos((math.pi/180)*(sigma))*math.cos((math.pi/180)*(15*(t-to))))
+    # # optical air mass number (Eq. 11.12)
+    # m = pa/(101.3*math.cos((math.pi/180)*(psi)))
+    # # hourly flux density of solar radiation perpendicular to solar beam [W/m^2] (Eq 11.11)
+    # sph = spo * math.power(tao, m)
+    # # hourly flux density of solar radiation on a horizontal surface [W/m^2] (Eq. 11.8)
+    # sbh = sph * math.cos((math.pi/180)*(psi))
+    # # hourly flux density of diffuse radiation on a surface [W/m^2] (Eq. 11.13)
+    # sdh = 0.3 * (1-math.power(tao, m)) * sph * math.cos((math.pi/180)*(psi))
+    # # hourly total solar radiation [W/m^2] (Eq. 11.10)
+    # sth = sbh + sdh
+    # # daily averaged solar radiation (Rgmax) in MJ/m^2/day
+    # max_radiation = sum(sth) * 3600/1e6
+
+    # # replace max radiation with higher measured radiation
+    # if max_radiation < solar_radiation:
+    #     max_radiation = solar_radiation
+    # else:
+    #     pass
+
+    # return max_radiation, day_length
+
+    return solar_radiation, day_length
+
+def _calculate_cloud_correction(solar_radiation: int, max_radiation: int):
+
+    clouds = 0.2 + 0.8*(solar_radiation/max_radiation)
+
+    return clouds

--- a/aquacrop/utils/prepare_weather.py
+++ b/aquacrop/utils/prepare_weather.py
@@ -1,19 +1,20 @@
 #-----------------------------------------------------------------------------------------
 # CHANGES IMPLEMENTED BY KADE FLYNN AUGUST 2025
 #-----------------------------------------------------------------------------------------
-#- Add function prepare_weather_from_daymet() to format weather data downloaded from Daymet (https://daymet.ornl.gov/) for use in Aquacrop. As part of this function, reference ET is calculated...
+#- Add function prepare_weather_minimum_data() to format weather data that conly contains minimum weather variables of minimum temperature, maximum temperature, incoming shortwave (solar) radiation, precipitation, vapor pressure. As part of this function, reference ET is calculated...
 #- Add function to calculate Reference ET according to Allen (1998). Wind speed data is   assumed to be equal to 2 m/s.
 #- Add functions to calculate net radiaition from input weather data. Net radiation calculation is based on equations in An Introduction to Environmental Biophysics (Campbell and Norman, 1998). Equations include:
 #   - calculate_net_radiation()
-#   - _calculate_saturated_vapor_pressure()
-#   - _calculate_clear_sky_emissivity()
-#   - _calculate_total_radiant_energy_emmitted()
-#   - _calculate_max_radiation
-#   - _calculate_cloud_correction()
+#   - calculate_mean_temperature()
+#   - calculate_saturated_vapor_pressure()
+#   - calculate_clear_sky_emissivity()
+#   - calculate_total_radiant_energy_emmitted()
+#   - calculate_max_radiation
+#   - calculate_cloud_correction()
 #-----------------------------------------------------------------------------------------
 
 import pandas as pd
-import numpy as np  # required for changes implemented by kade flynn AUgust 2025
+import numpy as np  # required for changes implemented by kade flynn August 2025
 
 
 def prepare_weather(weather_file_path):
@@ -54,222 +55,364 @@ weather_df (pandas.DataFrame):  weather data for simulation period
 
     return weather_df
 
-def prepare_weather_from_daymet(weather_file_path: str, latitude: float, longitude: float, elevation: float):
+def prepare_weather_minimum_data(weather_file_path: str, latitude: float, longitude: float, elevation: float):
     """
-    function to read in weather data from DAYMET and return a dataframe containing the weather data.
+    Function to read in minimumly available weather data (minimum temperature, maximum temperature, incoming shortwave (solar) radiation, precipitation, vapor pressure) and return a dataframe containing weather data formatted for Aquacrop. These weather variables are commonly available for gridded weather datasets such as Daymet (https://daymet.ornl.gov/). This function uses these data to calculate reference ET.
 
-    Arguments:
-    - file path to daymmet download. File structure:
-        - Column names begin on row 7
-        - Columns are:
-            - year, yday, dayl (s), srad (W/m^2), swe (kg/m^2), tmax (deg c) tmin (deg c), vp(Pa)
-    - latitude
-    -longitude
-    -elevation
+    Parameters:
+    -----------
+    weather_file_path: str
+        Path to weather file containing minimum data.
+    latitude: float
+        Latitude of simulation location.
+    longitude: float
+        Longitude of simulation location.
+    elevation: 
+        Elevation of simulation location.
 
-    Returns:
-    - weather_df (pandas.DataFrame):  weather data for simulation period
+    Result:
+    -------
+    weather_df: pandas.DataFrame
+        Data frame containing weather data for Aquacrop
 
     """
-
-    weather_df = pd.read_csv(weather_file_path, skiprows=6, header=0)
-
-    assert len(weather_df.columns) == 9
+    weather_df = pd.read_csv(weather_file_path, header=0)
+    assert len(weather_df.columns) == 7
 
     # rename the columns
     weather_df.columns = str(
-        "Year Yday Dayl_s Precip_mm Srad_wm2 Swe_kgm2 Tmax_c Tmin_c Vp_pa").split()
+        "Year YearDay Precipitation Solar MaxTemp MinTemp VaporPressure").split()
 
     # put the weather dates into datetime format
-    weather_df['Date_Yj'] = pd.to_datetime(weather_df['Year'].astype(str) + '-' + weather_df['Yday'].astype(str), format='%Y-%j')
+    weather_df['Date_Yj'] = pd.to_datetime(weather_df['Year'].astype(str) + '-' + weather_df['YearDay'].astype(str), format='%Y-%j')
     weather_df['Date'] = weather_df['Date_Yj'].dt.strftime('%Y-%m-%d')
-
-    # drop the  date in year-yday format columns
     weather_df = weather_df.drop(["Date_Yj"], axis=1)
 
-    # calculate incoming shortwave (solar) radiation
-    weather_df['Solar_mjm2'] = weather_df['Srad_wm2'] * weather_df['Dayl_s'] / 1_000_000
+    # calculate mean temperature
+    weather_df['MeanTemp'] = calcualte_mean_temperature(
+        minimum_temperature = weather_df['MinTemp'],
+        maximum_temperature = weather_df['MaxTemp'])
 
-    # drop shortwave radiation flux density, day length, snow water equivalent
-    weather_df = weather_df.drop(['Srad_wm2', 'Dayl_s', 'Swe_kgm2'], axis=1)
+    # calculate vapor pressure
+    weather_df['SatVaporPressure'], weather_df['Delta'] = calculate_saturated_vapor_pressure(weather_df['MeanTemp'])
 
     # Calculate Net Radiation
-    weather_df['Rn'] = calculate_net_radiation(Tmin = weather_df['Tmin_c'],
-                                               Tmax = weather_df['Tmax_c'],
-                                               Solar = weather_df['Solar_mjm2'],
-                                               Vp = weather_df['Vp_pa'],
-                                               Yday = weather_df['Yday'],
-                                               Latitude = latitude,
-                                               Longitude = longitude,
-                                               Elevation = elevation)
+    weather_df['NetRadiation'] = calculate_net_radiation(
+        mean_temperature= weather_df['MeanTemp'],
+        solar_radiation = weather_df['Solar'],
+        vapor_pressure = weather_df['VaporPressure'],
+        saturated_vapor_pressure = weather_df['SatVaporPressure'],
+        delta = weather_df['Delta'],
+        year_day = weather_df['YearDay'],
+        latitude = latitude,
+        longitude = longitude,
+        elevation = elevation)
+    
     # Calculate Reference ET
-    weather_df['ReferenceET'] = calculate_reference_et()
+    weather_df['ReferenceET'] = calculate_reference_et(
+        net_radiation = weather_df['NetRadiation'],
+        vapor_pressure=weather_df['VaporPressure'],
+        saturated_vapor_pressure=weather_df['SatVaporPressure'],
+        delta=weather_df['Delta'],
+        Tmean = weather_df['MeanTemp'])
 
     # set limit on ET0 to avoid divide by zero errors
-    #weather_df['ReferenceET'] = weather_df['ReferenceET'].clip(lower=0.1)
+    weather_df['ReferenceET'] = weather_df['ReferenceET'].clip(lower=0.1)
 
     return weather_df
 
 
-def calculate_reference_et(Rn, Vp):
-    '''Calculate Reference ET with the FAO Penman-Monteith equation (Equation 3, Allen et al. 1998).
-    
-    Arguments:
-    -net radiation
-    -soil heat flux
-    -vapor pressure
-    -saturated vapor pressure
-    -minimum daily temperatuer
-    -maximum daily temperature
-    -psychrometric constant 
-    '''
-    numerator
+def calculate_reference_et(net_radiation: float, vapor_pressure: float, saturated_vapor_pressure: float, delta: float, mean_temperature: float, wind_speed = 2, ground_heat_flux = 0):
 
-def calculate_net_radiation(Tmin, Tmax, Solar, Vp, Yday, Latitude, Longitude, Elevation):
+    '''Calculate Reference ET with the FAO Penman-Monteith equation (Equation 6, Allen et al. 1998).
+
+    Parameters:
+    -----------
+    net_radiation: float
+        Net radiation (Mj/m^2). Can be calcualted with the calculate_net_radiation() function
+    vapor_pressure : float
+        Vapor pressure (kPa)
+    saturated_vapor_pressure: float
+        Saturated vapor pressure (kPa)
+    delta : float
+        Slope of the saturated vapor pressure temperature curve
+    mean_temperature: float
+        Average daily temperature (decrees C)
+    wind_speed: float
+        Wind speed (m/s). Unless specified, assumed to be 2 m/s based on recommendation of Allen et al. (1998)
+    ground_heat_flux: float
+        Ground heat Flux. Unless specified, assumed to be 0. This is an appropriate assumption for daily time scales (Allen et al. 1998)
+    
+    Result:
+    -------
+    ReferenceET: float
+        Reference Evapotranspiration for a grass surface.
+    '''
+    # Equation 8 Allen et al. (1998)
+    psychrometric_constant = 0.665e-3 * vapor_pressure
+    
+    # vapor pressure deficit
+    vapor_pressure_deficit = saturated_vapor_pressure - vapor_pressure
+
+
+    numerator = 0.408 * delta * (net_radiation - ground_heat_flux) + psychrometric_constant * (900 / (mean_temperature + 273)) * wind_speed * vapor_pressure_deficit
+
+    denominator = delta + psychrometric_constant * (1 + 0.34 * wind_speed)
+
+    return numerator / denominator
+
+def calculate_net_radiation(mean_temperature, solar_radiation, vapor_pressure, saturated_vapor_pressure, delta, year_day, latitude, longitude, elevation):
     '''
     Function to calculate the net radiation. General reference is An Introduction to Environmental Biophysics (Campbell and Norman, 1998).
 
     Parameters:
     -----------
-    Tmin : float
-        Minimum daily temperature in degrees celcius
-    Tmax : float
-        Maximum daily temperature in degrees celsius
-    Solar: float
+    mean_temperature : float
+        Mean daily temperature in degrees celcius
+    solar_radiation: float
         Incoming shortwave (solar) radiation in Mj/m^2
-    Vp : float
-        Vapor pressure in Pascales 
-    Latitude: float
-        latitude in degrees
-    Longitude: float
-        longitude in degrees
+    vapor_pressure : float
+        Vapor pressure (kPa)
+    saturated_vapor_pressure: float
+        Saturated vapor pressure (kPa)
+    delta : float
+        Slope of the saturated vapor pressure temperature curve.
+    year_day: int
+        Day of year.
+    latitude: float
+        Latitude of simulation location in degrees.
+    longitude: float
+        Longitude of simulation location in degrees.
+    elevation: float
+        Elevation of simulation location (m).
     
     Result:
     -------
-    NetRadiation
-        Object containing the net radiation and related variables
+    NetRadiation: float
+        Net radiation at the simulation location.
     '''
-    Temperature = (Tmin + Tmax) / 2
 
-    saturated_vapor_pressure, slope_saturated_vapor_pressure_curve = _calculate_saturated_vapor_pressure(temperature = Temperature)
+    clear_sky_emissivity = calculate_clear_sky_emissivity(
+        mean_temperature = mean_temperature,
+        vapor_pressure = vapor_pressure)
 
-    clear_sky_emissivity = _calculate_clear_sky_emissivity(temperature = Temperature, vapor_pressure = Vp)
-
-    total_radiant_energy_emitted = _calculate_total_radiant_energy_emitted(temperature = Temperature, clear_sky_emissivity = clear_sky_emissivity)
+    total_radiant_energy_emitted = calculate_total_radiant_energy_emitted(
+        mean_temperature = mean_temperature,
+        clear_sky_emissivity = clear_sky_emissivity)
     
-    max_radiation, day_length = _calculate_max_radiation(latitude = Latitude, longitude = Longitude, standard_meridian = Longitude, elevation = Elevation, day_of_year = Yday, solar_radiation = Solar)
+    max_radiation, day_length = calculate_max_radiation(
+        latitude = latitude,
+        longitude = longitude,
+        elevation = elevation,
+        day_of_year = year_day,
+        solar_radiation = solar_radiation)
     
-    cloud_correction = _calculate_cloud_correction(solar_radiation = Solar, max_radiation = max_radiation)
+    cloud_correction = calculate_cloud_correction(
+        solar_radiation = solar_radiation,
+        max_radiation = max_radiation)
 
     albedo = 0.23
-    net_radiation = Solar * (1-albedo) + total_radiant_energy_emitted * cloud_correction
+
+    net_radiation = solar_radiation * (1-albedo) + total_radiant_energy_emitted * cloud_correction
 
     return net_radiation
 
-def _calculate_saturated_vapor_pressure(temperature):
+def calcualte_mean_temperature(minimum_temperature: float, maximum_temperature: float) -> float:
+    ''' 
+    Calculate the mean temperature
+
+    Parameters:
+    ----------
+    minimum_temperature: float
+    maximum_temperature: float
+
+    Result:
+    -------
+    mean_temperature: float
     '''
-    Function to calculate the saturated vapor pressure and the slope of the saturated vapor pressure curve
-    using Tetens formula. Equation 3.8 from An Introduction to Environmental Biophysics (Campbell and Norman, 1998).
+    return (minimum_temperature + maximum_temperature) / 2
+
+def calculate_saturated_vapor_pressure(mean_temperature):
+    '''
+    Function to calculate the saturated vapor pressure and the slope of the saturated vapor pressure curve using Tetens formula. Equation 3.8 from An Introduction to Environmental Biophysics (Campbell and Norman, 1998).
+
+    Parameters:
+    -----------
+    mean_temperature: float
+        Average daily temperature (degrees C).
+    
+    Result:
+    ------
+    Tuple(saturated_vapor_pressure, slope_saturated_vapor_pressure_curve)
     '''
     a = 0.611
     b = 17.502
     c = 240.970
-    saturated_vapor_pressure = a * (np.exp(b*temperature/(temperature+c)))
+
+    saturated_vapor_pressure = a * (np.exp(b*mean_temperature/(mean_temperature+c)))
 
     slope_saturated_vapor_pressure_curve = b*c*saturated_vapor_pressure/\
-        ((temperature+c)**2) / 101.3
+        ((mean_temperature+c)**2) / 101.3
 
     return saturated_vapor_pressure, slope_saturated_vapor_pressure_curve
 
-def _calculate_clear_sky_emissivity(temperature: int, vapor_pressure: int):
+def calculate_clear_sky_emissivity(mean_temperature: int,
+                                   vapor_pressure: int):
     '''
     Function to calculate the clear sky emissivity. Equation 10.10 from An Introduction to
     Environmental Biophysics (Campbell and Norman, 1998).
+
+    Paramters:
+    ---------
+    mean_temperature: float
+        Average daily temperature (degrees C).
+    vapor_pressure: float
+        Vapor pressure (kPa).
+
+    Result:
+    -------
+    clear_sky_emissivity: float
+        The clear sky emissivity. Used to calcualte net radiation
     '''
 
-    clear_sky_emissivity = 1.72 * ((vapor_pressure/1000)/(temperature+273))**(1/7)
+    clear_sky_emissivity = 1.72 * ((vapor_pressure)/(mean_temperature+273))**(1/7)
 
     return clear_sky_emissivity
 
-def _calculate_total_radiant_energy_emitted(temperature: int, clear_sky_emissivity: int):
+def calculate_total_radiant_energy_emitted(mean_temperature: int,
+                                           clear_sky_emissivity: int):
     '''
     Function to calculate the total radiant energy emitted by a blackbody. Equation 10.9 from An Introduction to
     Environmental Biophysics (Campbell and Norman, 1998).
+
+    Paramters:
+    ---------
+    mean_temperature: float
+        Average daily temperature (degrees C).
+    clear_sky_eissivity: float
+        The clear sky emissivity. Calculated with function calculate_clear_sky_emissivity().
+
+    Result:
+    -------
+    total_radiant_energy_emitted: float
+        total radiant energy emitted by a blackbody.
     '''
 
-    total_radiant_energy_emitted = 0.98 * (clear_sky_emissivity-1) * 5.67e-8 * (temperature+273)**4
+    total_radiant_energy_emitted = 0.98 * (clear_sky_emissivity-1) * 5.67e-8 * (mean_temperature+273)**4
     # convert to Mj/m2. Output of Stefan-Boltzmann law is W/m2
     total_radiant_energy_emitted = total_radiant_energy_emitted * 14 * 3600 * 1e-6
 
     return total_radiant_energy_emitted
 
 
-def _calculate_max_radiation(latitude: int, longitude: int, standard_meridian: int,
-                              elevation: int, day_of_year: int, solar_radiation: int):
+def calculate_max_radiation(latitude: int,
+                            longitude: int,
+                            elevation: int,
+                            day_of_year: int,
+                            solar_radiation: int):
     '''
     Function to calculate the maximum radiation for a given location. General reference
     is An Introduction to Environmental Biophysics (Campbell and Norman, 1998). pages 168 to 173.
+    Parameters:
+    -----------
+    latitute: float
+    longitude: float
+    elevation: float
+    day_of_year: float
+    solar_radiation: float
+
+    Result:
+    -------
+    max_radiation, day_length
+
     '''
+    standard_meridian = longitude
+
     # extraterrestrial flux density normal to the solar beam [W/m^2]
     spo = 1360
+
     # atmoshperic transmittance
     tao = 0.75
+
     # calculate atmospheric pressure
     pa = 101.3 * np.exp(-elevation/8200)
+
     # Equation of time (Eq. 11.4)
     f = 279.575 + 0.9856 * day_of_year
-    # convert f from radians to degrees
     f = f * (np.pi / 180)
 
     et = (-104.7 * np.sin((f)) + 596.2 * np.sin((2*f)) + 4.3*np.sin((3*f)) -\
           12.7*np.sin((4*f)) - 429.3*np.cos((f)) - 2*np.cos((2*f)) +\
             19.3*np.cos((3*f))) / 3600
+    
     # solar declination angle in degrees (Eq. 11.5)
     sigma = (180/np.pi) * (np.asin(0.39785*np.sin((np.pi/180)*(278.97 + 0.9856*day_of_year + 1.9165*\
                                                                    np.sin((np.pi/180)*(356.6+0.9856*day_of_year))))))
+    
     # longitude correction
     lc = (standard_meridian-longitude) / 15
+    
     # solar noon (Eq 11.3)
     to = 12 - lc - et
+    
     # Calculate half day length in degrees (Eq 11.6)
     hs = (180 / np.pi) * np.acos(-np.sin((np.pi/180)*(latitude)) * np.sin((np.pi/180)*(sigma)) /\
                                      (np.cos((np.pi/180)*(latitude))*np.cos((np.pi/180)*(sigma))))
+    
     # time of sunrise (Eq 11.7)
     tr = np.round(0.5 + (to - hs/15))
+    
     # time of sunset
     ts = np.round((to + hs/15) - 0.5)
+
     # hours in day from sunrise to sunset 
-    #t = [x for x in range(tr, ts, 1)]
-    # get daylength
-    #day_length = len(t)
-    day_length = ts - tr
-    # # hourly zenith angle  (Eq. 11.1)
-    # psi = 180/math.pi * math.acos(math.sin((math.pi/180)*(latitude))*math.sin((math.pi/180)*(sigma)) + math.cos((math.pi/180)*(latitude))*\
-    #                             math.cos((math.pi/180)*(sigma))*math.cos((math.pi/180)*(15*(t-to))))
-    # # optical air mass number (Eq. 11.12)
-    # m = pa/(101.3*math.cos((math.pi/180)*(psi)))
-    # # hourly flux density of solar radiation perpendicular to solar beam [W/m^2] (Eq 11.11)
-    # sph = spo * math.power(tao, m)
-    # # hourly flux density of solar radiation on a horizontal surface [W/m^2] (Eq. 11.8)
-    # sbh = sph * math.cos((math.pi/180)*(psi))
-    # # hourly flux density of diffuse radiation on a surface [W/m^2] (Eq. 11.13)
-    # sdh = 0.3 * (1-math.power(tao, m)) * sph * math.cos((math.pi/180)*(psi))
-    # # hourly total solar radiation [W/m^2] (Eq. 11.10)
-    # sth = sbh + sdh
-    # # daily averaged solar radiation (Rgmax) in MJ/m^2/day
-    # max_radiation = sum(sth) * 3600/1e6
+    t = pd.Series([np.arange(start, stop, 1, dtype=np.float64) for start, stop in zip(tr, ts)])
+    day_length = len(t)
 
-    # # replace max radiation with higher measured radiation
-    # if max_radiation < solar_radiation:
-    #     max_radiation = solar_radiation
-    # else:
-    #     pass
+    # hourly zenith angle  (Eq. 11.1)
+    psi_arrays = [
+        180/np.pi * np.arccos(np.sin((np.pi/180)*latitude)*np.sin((np.pi/180)*sigma) + 
+                          np.cos((np.pi/180)*latitude)*np.cos((np.pi/180)*sigma)*
+                          np.cos((np.pi/180)*(15*(t_array-to))))
+        for t_array, to, sigma in zip(t, to, sigma)]
+    psi = pd.Series(psi_arrays, dtype=object)
 
-    # return max_radiation, day_length
+    # optical air mass number (Eq. 11.12)
+    m_arrays = [
+        pa/(101.3*np.cos((np.pi/180)*(psi_array)))
+                for psi_array in psi]
+    m = pd.Series(m_arrays, dtype=object)
 
-    return solar_radiation, day_length
+    # hourly flux density of solar radiation perpendicular to solar beam [W/m^2] (Eq 11.11)
+    sph_arrays = [spo * np.power(tao, m_array)
+                 for m_array in m]
+    sph = pd.Series(sph_arrays, dtype=object)
 
-def _calculate_cloud_correction(solar_radiation: int, max_radiation: int):
+    # hourly flux density of solar radiation on a horizontal surface [W/m^2] (Eq. 11.8)
+    sbh_arrays = [sph_array * np.cos((np.pi/180)*(psi_array))
+                 for sph_array, psi_array in zip(sph, psi)]
+    sbh = pd.Series(sbh_arrays, dtype=object)
+
+    # hourly flux density of diffuse radiation on a surface [W/m^2] (Eq. 11.13)
+    sdh_arrays = [0.3 * (1-np.power(tao, m_array)) * sph_array * np.cos((np.pi/180)*(psi_array))
+                  for m_array, sph_array, psi_array in zip(m, sph, psi)]
+    sdh = pd.Series(sdh_arrays, dtype=object)
+
+    # hourly total solar radiation [W/m^2] (Eq. 11.10)
+    sth = [sbh_array + sdh_array
+           for sbh_array, sdh_array in zip(sbh, sdh)]
+    
+    # daily averaged solar radiation (Rgmax) in MJ/m^2/day
+    max_radiation_array = [sum(sth_array) * 3600/1e6
+                     for sth_array in sth]
+    max_radiation = pd.Series(max_radiation_array, dtype=object)
+
+    # replace max radiation with higher measured radiation
+    max_radiation = np.maximum(max_radiation, solar_radiation)
+
+    return max_radiation, day_length
+
+def calculate_cloud_correction(solar_radiation: int, max_radiation: int):
 
     clouds = 0.2 + 0.8*(solar_radiation/max_radiation)
 

--- a/tests/test_prepare_weather.py
+++ b/tests/test_prepare_weather.py
@@ -1,0 +1,34 @@
+from aquacrop.utils import get_filepath, prepare_weather, prepare_weather_minimum_data
+
+import pandas as pd
+
+import pydaymet
+import pygridmet
+
+# read in aquacrop example data
+filepath_1 = get_filepath('champion_climate.txt')
+print(filepath_1)
+filepath_2 = get_filepath('weather_minimum_lat38.9_lon-83.9_elev291.csv')
+print(filepath_2)
+
+# prepare weather data with two methods and compare
+weather_data_1 = prepare_weather(filepath_1)
+weather_data_2= prepare_weather_minimum_data(filepath_2, 38.9, -83.9, 291)
+print(weather_data_1)
+print(weather_data_2)
+
+
+weather_data_2.to_clipboard()
+
+# use py daymet to get weather for given location
+coords = (-83.9, 38.9)
+crs = 4326
+dates = ("1980-01-01", "2023-12-31")
+pydaymet_data_2 = pydaymet.get_bycoords(coords, dates, variables=['tmin', 'tmax', 'prcp', 'srad', 'vp', 'swe', 'dayl'], crs=crs, time_scale='daily', pet='priestley_taylor')
+print(pydaymet_data_2)
+pydaymet_data_2.to_clipboard()
+
+
+pygridmet_data_2 = pygridmet.get_bycoords(coords, dates, crs=crs)
+print(pygridmet_data_2)
+pygridmet_data_2.to_clipboard()


### PR DESCRIPTION
This adds a new function format_weather_minimum_data() Which takes weather data that does not include reference ET and formats it for use in Aquacrop, including by calculating reference ET. This new function is created to allow weather data from gridded sources, such as Daymet, to be used as input without extensive pre-processing. 

Equations used to calculate net radiation come from An Introduction to Environmental Biophysics.(https://cdn.preterhuman.net/texts/science_and_technology/nature_and_biology/Biophysics/An%20Introduction%20To%20Environmental%20Biophysics%20-%20Gaylon%20S.%20Campbell,%20John%20M.%20Norman.pdf)

Reference ET calculation is based on FAO guidelines (Allen et al., 1998)

Comparisons were made against open-source weather generation python packages in the HyRiver suite of packages (https://docs.hyriver.io/index.html). A weather file downloaded from Daymet was used for testing in the script test_prepare_weather.py in tests. Results are shown in attached figures:


<img width="1573" height="933" alt="image" src="https://github.com/user-attachments/assets/229646c9-1143-4437-9067-97e3bb2ff8f5" />

<img width="1659" height="724" alt="image" src="https://github.com/user-attachments/assets/fa0ac540-69bc-465b-8132-f80c9f46d85d" />
